### PR TITLE
Option to set FLOW_CONTEXT via env variable in prod image

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ And run it:
 The `prod` image differs from the `dev` image in a few aspects:
 
 1. Of course, the `FLOW_CONTEXT` environment variable is set to `PRODUCTION` in
-   the `prod` image. Duh.
+   the `prod` image. You can, however, override it on container creation (usually
+   with the `-e FLOW_CONTEXT=...` flag).
 2. On startup, the TYPO3 Flow Cache will be warmed up by executing a
    `./flow flow:cache:warmup` on startup.
 3. Furthermore, Doctrine migration will be executed if necessary on startup

--- a/prod/Dockerfile
+++ b/prod/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:15.04
 
+ENV FLOW_CONTEXT Production
+
 RUN apt-get update
 RUN apt-get install -y nginx
 RUN apt-get install -y php5-fpm php5-mcrypt php5-mysqlnd php5-curl php5-gd php5-json php5-xsl php5-cli php5-imagick

--- a/prod/start.sh
+++ b/prod/start.sh
@@ -52,4 +52,7 @@ fi
 echo "Setting Flow context in Nginx config"
 sed -i -e",Production,$FLOW_CONTEXT,g" /etc/nginx/sites-enabled/default
 
+echo "Setting Flow context in FPM config"
+sed -i -e",Production,$FLOW_CONTEXT,g" /etc/php5/fpm/pool.d/www.conf
+
 exec /usr/bin/supervisord

--- a/prod/start.sh
+++ b/prod/start.sh
@@ -49,4 +49,7 @@ if [ $? -ne 0 ] ; then
     exit 1
 fi
 
+echo "Setting Flow context in Nginx config"
+sed -i -e",Production,$FLOW_CONTEXT,g" /etc/nginx/sites-enabled/default
+
 exec /usr/bin/supervisord


### PR DESCRIPTION
This PR adds an option to override the `FLOW_CONTEXT` environment variable in the `prod` image (up until now, it defaulted to `Production`).

Just start the container with `-e FLOW_CONTEXT=Production/QA` or any other context.
