### PR TITLE
Finish migrating to Ubuntu 18.04

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
         php5.6-cli \
         php5.6-imagick \
         php5.6-mbstring \
+        php5.6-soap \
         supervisor
 
 RUN useradd -d /var/www flow

--- a/prod/Dockerfile
+++ b/prod/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && \
         php5.6-cli \
         php5.6-imagick \
         php5.6-mbstring \
+        php5.6-soap \
         supervisor
 
 RUN useradd -d /var/www flow

--- a/prod/start.sh
+++ b/prod/start.sh
@@ -53,7 +53,7 @@ echo "Setting Flow context in Nginx config"
 sed -i -e"s,Production,$FLOW_CONTEXT,g" /etc/nginx/sites-enabled/default
 
 echo "Setting Flow context in FPM config"
-sed -i -e"s,Production,$FLOW_CONTEXT,g" /etc/php5/fpm/pool.d/www.conf
+sed -i -e"s,Production,$FLOW_CONTEXT,g" /etc/php/5.6/fpm/pool.d/www.conf
 
 mkdir /run/php
 


### PR DESCRIPTION
At least for the relocation management tool it now finally works without problems.
Tested by manually installing the missing package inside the container